### PR TITLE
fixed import path

### DIFF
--- a/FinderMenu/main.m
+++ b/FinderMenu/main.m
@@ -9,7 +9,7 @@
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
 
-#import "mach_inject_bundle/mach_inject_bundle.h"
+#import "../mach_inject/mach_inject_bundle/mach_inject_bundle.h"
 
 int main(int argc, const char * argv[])
 {


### PR DESCRIPTION
Got error:
`/Users/seven/Dropbox/git/FinderMenu/FinderMenu/main.m:12:9: fatal error: '../mach_inject_bundle/mach_inject_bundle.h' file not found
# import "mach_inject_bundle/mach_inject_bundle.h"

```
    ^
```

1 error generated.`

Running on OSX 10.8.3
